### PR TITLE
feat: add reverse proxy support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,14 @@ UNRAID_IS_HTTPS=
 UNRAID_USERNAME=
 UNRAID_PASSWORD=
 JWT_SECRET=
+
+# Server
+# SERVER_PORT=8787
+# SERVE_FRONTEND=true            # Serve frontend static files from Express (single-port mode)
+# FRONTEND_DIST_PATH=../frontend/dist
+
+# Proxy
+# TRUST_PROXY=false              # true, 1 (number of hops), or "10.0.0.0/8,loopback" (CIDR/subnet string)
+
+# CORS
+# CORS_ORIGIN=*

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN pnpm install && \
     pnpm run build:frontend && \
     pnpm run build:backend
 
-EXPOSE 8786
 EXPOSE 8787
 
-CMD ["pnpm", "run", "start:all"]
+CMD ["pnpm", "run", "start:prod"]

--- a/backend/src/api/v1/config/config.ts
+++ b/backend/src/api/v1/config/config.ts
@@ -1,0 +1,28 @@
+import express, { Response } from 'express';
+
+import { config } from '../../../config.js';
+import { authCheck } from '../../../middleware/authCheck.js';
+import { validateReq } from '../../../middleware/validateReq.js';
+import { errorHandler } from '../../../services/ErrorHandler.js';
+import { respondSuccess } from '../../../services/responses.js';
+
+const router = express.Router();
+
+router.get('/',
+  [
+    authCheck,
+    validateReq,
+  ],
+  async (_req: any, res: Response) => {
+    try {
+      return res.json(respondSuccess({
+        unraidBaseUrl: config.unraid.baseUrl,
+      }));
+    } catch (error) {
+      console.error('ERROR - /config', error);
+      return errorHandler(res, error);
+    }
+  }
+);
+
+export default router;

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -2,15 +2,33 @@ import * as dotenv from 'dotenv'
 
 dotenv.config();
 
+const parseTrustProxy = (value?: string): boolean | number | string => {
+  if (!value || value === 'false') return false;
+  if (value === 'true') return true;
+  const num = parseInt(value, 10);
+  if (!isNaN(num)) return num;
+  return value;
+};
+
+const unraidIsHTTPS = process.env.UNRAID_IS_HTTPS !== '' && process.env.UNRAID_IS_HTTPS === 'true';
+const unraidIp = process.env.UNRAID_IP;
+
 export const config = {
   unraid: {
-    ip: process.env.UNRAID_IP,
-    isHTTPS: process.env.UNRAID_IS_HTTPS !== '' && process.env.UNRAID_IS_HTTPS === 'true',
+    ip: unraidIp,
+    isHTTPS: unraidIsHTTPS,
     username: process.env.UNRAID_USERNAME,
     password: process.env.UNRAID_PASSWORD,
+    baseUrl: `http${unraidIsHTTPS ? 's' : ''}://${unraidIp}`,
   },
   server: {
-    port: 8787,
+    port: parseInt(process.env.SERVER_PORT || '8787', 10),
+    serveFrontend: process.env.SERVE_FRONTEND !== 'false',
+    frontendDistPath: process.env.FRONTEND_DIST_PATH || '../frontend/dist',
+    trustProxy: parseTrustProxy(process.env.TRUST_PROXY),
+  },
+  cors: {
+    origin: process.env.CORS_ORIGIN || '*',
   },
   jwt: {
     secret: process.env.JWT_SECRET,

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import cors from 'cors';
+import path from 'path';
 
 import { config } from './config.js';
 import { sequelize } from './services/db.js';
@@ -7,15 +8,20 @@ import { syncModels } from './models/syncModels.js';
 
 // Routes
 import authRoute from './api/v1/auth/auth.js';
+import configRoute from './api/v1/config/config.js';
 import userRoute from './api/v1/users/users.js';
 import vmRoute from './api/v1/vms/vms.js';
 
 const app = express();
 
-// Cors
-app.use(cors());
+app.set('trust proxy', config.server.trustProxy);
 
-app.use(express.json());
+app.use(cors({
+  origin: config.cors.origin,
+  credentials: true,
+}));
+
+app.use(express.json({ limit: '1mb' }));
 
 (async () => {
   try {    
@@ -27,8 +33,18 @@ app.use(express.json());
 
     // Routes
     app.use('/api/v1/auth', authRoute);
+    app.use('/api/v1/config', configRoute);
     app.use('/api/v1/users', userRoute);
     app.use('/api/v1/vms', vmRoute);
+
+    if (config.server.serveFrontend) {
+      const distPath = path.resolve(config.server.frontendDistPath);
+      app.use(express.static(distPath));
+      app.get('*', (_req, res, next) => {
+        if (_req.path.startsWith('/api')) return next();
+        res.sendFile(path.join(distPath, 'index.html'));
+      });
+    }
 
     // Start express
     app.listen(config.server.port, () => {

--- a/backend/src/services/unraid.ts
+++ b/backend/src/services/unraid.ts
@@ -227,7 +227,7 @@ export const extractVMsFromHTML = (vmsHTML, unraidIP) => {
     if (imgSrc && imgSrc.startsWith('./')) {
       imgSrc = imgSrc.substring(1);
     }
-    const osImg = `http://${unraidIP}${imgSrc}`;
+    const osImg = `${unraidIP}${imgSrc}`;
 
     const os = onclickAttr.match(/addVMContext\('.*?','.*?','(.*?)'/)[1];
     const vnc = onclickAttr.match(/addVMContext\('.*?','.*?','.*?','.*?','(.*?)'/)[1];

--- a/frontend/src/hooks/vm.tsx
+++ b/frontend/src/hooks/vm.tsx
@@ -1,6 +1,7 @@
 import { createSignal } from "solid-js"
 import toast from "solid-toast";
 import { useVMs } from "../contexts/vms";
+import { getUnraidBaseUrl } from "../services/config";
 import { forceStopVMApi, hibernateVMApi, pauseVMApi, removeVMAndDisksApi, removeVMApi, restartVMApi, resumeVMApi, startVMApi, stopVMApi, unlinkVMApi } from "../services/vms";
 
 export const useVMActions = (id: string, name: string) => {
@@ -160,10 +161,11 @@ export const useVMActions = (id: string, name: string) => {
     }
   }
 
-  const openVNC = () => {
-    const vm = vms().find((vm) => vm.id === id);
-    if (vm) {
-      window.open(`http://${location.hostname}${vm.vnc}`, '_blank');
+  const openVNC = async () => {
+    const v = vms().find((v) => v.id === id);
+    if (v) {
+      const baseUrl = await getUnraidBaseUrl();
+      window.open(`${baseUrl}${v.vnc}`, '_blank');
     }
   }
 

--- a/frontend/src/services/config.ts
+++ b/frontend/src/services/config.ts
@@ -1,0 +1,10 @@
+import { request } from './api';
+
+let cachedUnraidBaseUrl: string | null = null;
+
+export const getUnraidBaseUrl = async (): Promise<string> => {
+  if (cachedUnraidBaseUrl) return cachedUnraidBaseUrl;
+  const res = await request({ path: '/config' });
+  cachedUnraidBaseUrl = res.payload.unraidBaseUrl;
+  return cachedUnraidBaseUrl!;
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build:all": "pnpm run build:backend && pnpm run build:frontend",
     "start:backend": "cd backend && pnpm run start",
     "start:frontend": "cd frontend && pnpm run http",
-    "start:all": "concurrently --kill-others \"pnpm run start:backend\" \"pnpm run start:frontend\""
+    "start:all": "concurrently --kill-others \"pnpm run start:backend\" \"pnpm run start:frontend\"",
+    "start:prod": "pnpm run start:backend"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary

Adds full reverse proxy support, addressing #3. The key architectural change is that Express can now serve frontend static files, eliminating the need for a separate reverse proxy just to route `/api` requests between ports.

## Changes

### Single-port mode (default)
- Express serves frontend static files from `/` with SPA fallback, API routes at `/api/*`
- Docker image runs on a single port (8787) by default
- Set `SERVE_FRONTEND=false` to revert to legacy two-port arch

### New env vars
| Variable | Default | Purpose |
|---|---|---|
| `SERVER_PORT` | `8787` | Express port |
| `SERVE_FRONTEND` | `true` | Express serves frontend dist |
| `FRONTEND_DIST_PATH` | `../frontend/dist` | Path to built frontend |
| `TRUST_PROXY` | `false` | Supports `true`, hop count, or CIDR string |
| `CORS_ORIGIN` | `*` | Restrict CORS to specific origin |

### Proxy fixes
- CORS restricted via `CORS_ORIGIN` (default `*`, unchanged)
- `TRUST_PROXY` enables proper IP/protocol detection behind a proxy
- `express.json({ limit: '1mb' })` request body size limit

### VNC URL fix
- New `GET /api/v1/config` endpoint returns `unraidBaseUrl` with correct protocol
- Frontend uses this instead of hardcoded `http://${location.hostname}` which broke behind HTTPS proxies

### Bug fix
- `osImg` in VM listing had double-prefix (`http://http://...`) fixed

### Deployment
- New `pnpm run start:prod` script starts backend only (single-port mode)
- Docker CMD uses `start:prod`, exposes only port 8787
- Zero breaking changes for existing deployments using port 8787
