### PR TITLE
Fix Release Please Docker tag generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: Build and Push Docker Image
 
 on:
   workflow_call:
+    inputs:
+      version:
+        description: 'Version tag (e.g. v1.2.3)'
+        required: false
+        type: string
   push:
     tags:
       - 'v*'
@@ -19,7 +24,11 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/}
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION=${GITHUB_REF#refs/tags/}
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Lowercase repo name

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -24,6 +25,8 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     uses: ./.github/workflows/build.yml
+    with:
+      version: ${{ needs.release-please.outputs.tag_name }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## What

Fixes the Release Please build-and-push job which was failing with:

```
ERROR: failed to build: invalid tag "ghcr.io/npmsteven/unraid-vm-cp:refs/heads/master"
```

## Root Cause

When `build.yml` is called via `workflow_call` from `release-please.yml`, `GITHUB_REF` is `refs/heads/master` (the push event that triggered the caller), not a tag ref. The version extraction produced `heads/master`, which is an invalid Docker tag.

## Fix

1. **`build.yml`** — Accept an optional `version` input for `workflow_call`. When provided, use it as the Docker tag; when not (tag push event), fall back to `GITHUB_REF`.
2. **`release-please.yml`** — Pass the release tag name from the release-please step to `build.yml` as the `version` input.

Fixes #7