### PR TITLE
feat: migrate 6 VM actions from VMajax.php to GraphQL API

### DIFF
--- a/backend/__tests__/unraid-graphql.test.ts
+++ b/backend/__tests__/unraid-graphql.test.ts
@@ -1,0 +1,165 @@
+const mockAxios = jest.fn();
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: mockAxios,
+}));
+
+jest.mock('../src/config.js', () => ({
+  __esModule: true,
+  config: {
+    unraid: {
+      baseUrl: 'http://test-unraid:80',
+    },
+  },
+}));
+
+import { initGraphQLClient, startVM, stopVM, forceStopVM, rebootVM, pauseVM, resumeVM, _resetForTests } from '../src/services/unraid-graphql.js';
+
+const TEST_VM_ID = 'test-vm-uuid-123';
+
+describe('unraid-graphql', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _resetForTests();
+    initGraphQLClient(() => 'test-cookie');
+  });
+
+  const expectGraphQLCall = () => {
+    expect(mockAxios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'http://test-unraid:80/graphql',
+        method: 'POST',
+        headers: expect.objectContaining({ Cookie: 'test-cookie' }),
+      }),
+    );
+  };
+
+  describe('startVM', () => {
+    it('returns true on success', async () => {
+      mockAxios.mockResolvedValueOnce({
+        data: { data: { vm: { start: true } } },
+      });
+      const result = await startVM(TEST_VM_ID);
+      expect(result).toBe(true);
+      expectGraphQLCall();
+    });
+
+    it('throws on GraphQL error', async () => {
+      mockAxios.mockResolvedValueOnce({
+        data: { errors: [{ message: 'VM not found' }] },
+      });
+      await expect(startVM(TEST_VM_ID)).rejects.toThrow('VM not found');
+    });
+
+    it('throws on network error', async () => {
+      mockAxios.mockRejectedValueOnce(new Error('Network failure'));
+      await expect(startVM(TEST_VM_ID)).rejects.toThrow('Network failure');
+    });
+  });
+
+  describe('stopVM', () => {
+    it('returns true on success', async () => {
+      mockAxios.mockResolvedValueOnce({
+        data: { data: { vm: { stop: true } } },
+      });
+      const result = await stopVM(TEST_VM_ID);
+      expect(result).toBe(true);
+      expectGraphQLCall();
+    });
+
+    it('throws on GraphQL error', async () => {
+      mockAxios.mockResolvedValueOnce({
+        data: { errors: [{ message: 'Cannot stop stopped VM' }] },
+      });
+      await expect(stopVM(TEST_VM_ID)).rejects.toThrow('Cannot stop stopped VM');
+    });
+  });
+
+  describe('forceStopVM', () => {
+    it('returns true on success', async () => {
+      mockAxios.mockResolvedValueOnce({
+        data: { data: { vm: { forceStop: true } } },
+      });
+      const result = await forceStopVM(TEST_VM_ID);
+      expect(result).toBe(true);
+      expectGraphQLCall();
+    });
+
+    it('throws on GraphQL error', async () => {
+      mockAxios.mockResolvedValueOnce({
+        data: { errors: [{ message: 'Force stop failed' }] },
+      });
+      await expect(forceStopVM(TEST_VM_ID)).rejects.toThrow('Force stop failed');
+    });
+  });
+
+  describe('rebootVM', () => {
+    it('returns true on success', async () => {
+      mockAxios.mockResolvedValueOnce({
+        data: { data: { vm: { reboot: true } } },
+      });
+      const result = await rebootVM(TEST_VM_ID);
+      expect(result).toBe(true);
+      expectGraphQLCall();
+    });
+
+    it('throws on GraphQL error', async () => {
+      mockAxios.mockResolvedValueOnce({
+        data: { errors: [{ message: 'VM not running' }] },
+      });
+      await expect(rebootVM(TEST_VM_ID)).rejects.toThrow('VM not running');
+    });
+  });
+
+  describe('pauseVM', () => {
+    it('returns true on success', async () => {
+      mockAxios.mockResolvedValueOnce({
+        data: { data: { vm: { pause: true } } },
+      });
+      const result = await pauseVM(TEST_VM_ID);
+      expect(result).toBe(true);
+      expectGraphQLCall();
+    });
+
+    it('throws on GraphQL error', async () => {
+      mockAxios.mockResolvedValueOnce({
+        data: { errors: [{ message: 'VM not running' }] },
+      });
+      await expect(pauseVM(TEST_VM_ID)).rejects.toThrow('VM not running');
+    });
+  });
+
+  describe('resumeVM', () => {
+    it('returns true on success', async () => {
+      mockAxios.mockResolvedValueOnce({
+        data: { data: { vm: { resume: true } } },
+      });
+      const result = await resumeVM(TEST_VM_ID);
+      expect(result).toBe(true);
+      expectGraphQLCall();
+    });
+
+    it('throws on GraphQL error', async () => {
+      mockAxios.mockResolvedValueOnce({
+        data: { errors: [{ message: 'VM not paused' }] },
+      });
+      await expect(resumeVM(TEST_VM_ID)).rejects.toThrow('VM not paused');
+    });
+  });
+
+  describe('uninitialized client', () => {
+    it('throws when client not initialized', async () => {
+      _resetForTests();
+      await expect(startVM(TEST_VM_ID)).rejects.toThrow('GraphQL client not initialized');
+    });
+  });
+
+  describe('no cookie', () => {
+    it('throws when cookie getter returns empty', async () => {
+      _resetForTests();
+      initGraphQLClient(() => '');
+      await expect(startVM(TEST_VM_ID)).rejects.toThrow('Not authenticated with Unraid');
+    });
+  });
+});

--- a/backend/src/services/unraid-graphql.ts
+++ b/backend/src/services/unraid-graphql.ts
@@ -1,0 +1,83 @@
+import axios from 'axios';
+import { config } from '../config.js';
+import { BadRequestError } from './ErrorHandler.js';
+
+const GQL_URL = `${config.unraid.baseUrl}/graphql`;
+
+let _getCookie: () => string;
+
+export function initGraphQLClient(getCookie: () => string) {
+  _getCookie = getCookie;
+}
+
+export function _resetForTests() {
+  _getCookie = undefined as unknown as () => string;
+}
+
+async function gql(query: string, variables: Record<string, unknown>) {
+  if (!_getCookie) {
+    throw new BadRequestError('GraphQL client not initialized');
+  }
+  const cookie = _getCookie();
+  if (!cookie) {
+    throw new BadRequestError('Not authenticated with Unraid');
+  }
+  const { data } = await axios({
+    url: GQL_URL,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Cookie: cookie },
+    data: { query, variables },
+  });
+  if (data.errors?.length) {
+    throw new BadRequestError(data.errors[0].message);
+  }
+  return data.data;
+}
+
+export async function startVM(id: string) {
+  await gql(
+    `mutation StartVM($id: String!) { vm { start(id: $id) } }`,
+    { id },
+  );
+  return true;
+}
+
+export async function stopVM(id: string) {
+  await gql(
+    `mutation StopVM($id: String!) { vm { stop(id: $id) } }`,
+    { id },
+  );
+  return true;
+}
+
+export async function forceStopVM(id: string) {
+  await gql(
+    `mutation ForceStopVM($id: String!) { vm { forceStop(id: $id) } }`,
+    { id },
+  );
+  return true;
+}
+
+export async function rebootVM(id: string) {
+  await gql(
+    `mutation RebootVM($id: String!) { vm { reboot(id: $id) } }`,
+    { id },
+  );
+  return true;
+}
+
+export async function pauseVM(id: string) {
+  await gql(
+    `mutation PauseVM($id: String!) { vm { pause(id: $id) } }`,
+    { id },
+  );
+  return true;
+}
+
+export async function resumeVM(id: string) {
+  await gql(
+    `mutation ResumeVM($id: String!) { vm { resume(id: $id) } }`,
+    { id },
+  );
+  return true;
+}

--- a/backend/src/services/unraid.ts
+++ b/backend/src/services/unraid.ts
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { config } from '../config.js';
 import { BadRequestError, ForbiddenError } from './ErrorHandler.js';
 import { IUnraidVM } from '../types/IUnraidVM.js';
+import { startVM, stopVM, forceStopVM, rebootVM, pauseVM, resumeVM, initGraphQLClient } from './unraid-graphql.js';
 
 const { unraid } = config;
 
@@ -13,7 +14,7 @@ const setCookie = (cookie) => {
   cookieState.unraid = cookie;
 }
 
-const getCookie = () => {
+export const getCookie = () => {
   return cookieState?.unraid;
 }
 
@@ -26,6 +27,18 @@ const setCSRFToken = (csrfToken) => {
 const getCSRFToken = () => {
   return csrfTokenState.csrfToken;
 }
+
+let csrfTokenPromise: Promise<void> | null = null;
+
+const ensureCSRFToken = async () => {
+  if (getCSRFToken()) return;
+  if (csrfTokenPromise) return csrfTokenPromise;
+  csrfTokenPromise = getCSRFTokenUnraid();
+  await csrfTokenPromise;
+  csrfTokenPromise = null;
+}
+
+initGraphQLClient(getCookie);
 
 const unraidURI = `http${unraid.isHTTPS ? 's' : ''}://${unraid.ip}${unraid.port ? `:${unraid.port}` : ''}`;
 
@@ -71,7 +84,6 @@ export const login = async () => {
     if (!cookies) throw new ForbiddenError('Unable to login to unraid');
     const unraidCookie = cookies.find((cookie) => cookie.startsWith('unraid_'));
     setCookie(unraidCookie)
-    await getCSRFTokenUnraid();
   } catch (error) {
     console.error('ERROR - login():', error);
     throw error;
@@ -111,7 +123,7 @@ const requestVMajax = async (unraidVMId: string, action: string) => {
 
 export const startVMUnraid = async (unraidVMId: string) => {
   try {
-    return requestVMajax(unraidVMId, 'domain-start')
+    return await startVM(unraidVMId);
   } catch (error) {
     console.error('ERROR - startVMUnraid():', error);
     throw error;
@@ -120,15 +132,62 @@ export const startVMUnraid = async (unraidVMId: string) => {
 
 export const stopVMUnraid = async (unraidVMId: string) => {
   try {
-    return requestVMajax(unraidVMId, 'domain-stop');
+    return await stopVM(unraidVMId);
   } catch (error) {
     console.error('ERROR - stopVMUnraid():', error);
     throw error;
   }
 }
 
+export const forceStopVMUnraid = async (unraidVMId: string) => {
+  try {
+    return await forceStopVM(unraidVMId);
+  } catch (error) {
+    console.error('ERROR - forceStopVMUnraid():', error);
+    throw error;
+  }
+}
+
+export const restartVMUnraid = async (unraidVMId: string) => {
+  try {
+    return await rebootVM(unraidVMId);
+  } catch (error) {
+    console.error('ERROR - restartVMUnraid():', error);
+    throw error;
+  }
+}
+
+export const pauseVMUnraid = async (unraidVMId: string) => {
+  try {
+    return await pauseVM(unraidVMId);
+  } catch (error) {
+    console.error('ERROR - pauseVMUnraid():', error);
+    throw error;
+  }
+}
+
+export const resumeVMUnraid = async (unraidVMId: string) => {
+  try {
+    return await resumeVM(unraidVMId);
+  } catch (error) {
+    console.error('ERROR - resumeVMUnraid():', error);
+    throw error;
+  }
+}
+
+export const hibernateVMUnraid = async (unraidVMId: string) => {
+  try {
+    await ensureCSRFToken();
+    return requestVMajax(unraidVMId, 'domain-pmsuspend');
+  } catch (error) {
+    console.error('ERROR - hibernateVMUnraid():', error);
+    throw error;
+  }
+}
+
 export const removeVMUnraid = async (unraidVMId: string) => {
   try {
+    await ensureCSRFToken();
     return requestVMajax(unraidVMId, 'domain-undefine');
   } catch (error) {
     console.error('ERROR - removeVMUnraid():', error);
@@ -138,54 +197,10 @@ export const removeVMUnraid = async (unraidVMId: string) => {
 
 export const removeVMAndDisksVMUnraid = async (unraidVMId: string) => {
   try {
+    await ensureCSRFToken();
     return requestVMajax(unraidVMId, 'domain-delete');
   } catch (error) {
     console.error('ERROR - removeVMAndDisksVMUnraid():', error);
-    throw error;
-  }
-}
-
-export const forceStopVMUnraid = async (unraidVMId: string) => {
-  try {
-    return requestVMajax(unraidVMId, 'domain-destroy');
-  } catch (error) {
-    console.error('ERROR - forceStopVMUnraid():', error);
-    throw error;
-  }
-}
-
-export const restartVMUnraid = async (unraidVMId: string) => {
-  try {
-    return requestVMajax(unraidVMId, 'domain-restart');
-  } catch (error) {
-    console.error('ERROR - restartVMUnraid():', error);
-    throw error;
-  }
-}
-
-export const pauseVMUnraid = async (unraidVMId: string) => {
-  try {
-    return requestVMajax(unraidVMId, 'domain-pause');
-  } catch (error) {
-    console.error('ERROR - pauseVMUnraid():', error);
-    throw error;
-  }
-}
-
-export const resumeVMUnraid = async (unraidVMId: string) => {
-  try {
-    return requestVMajax(unraidVMId, 'domain-resume');
-  } catch (error) {
-    console.error('ERROR - resumeVMUnraid():', error);
-    throw error;
-  }
-}
-
-export const hibernateVMUnraid = async (unraidVMId: string) => {
-  try {
-    return requestVMajax(unraidVMId, 'domain-pmsuspend');
-  } catch (error) {
-    console.error('ERROR - hibernateVMUnraid():', error);
     throw error;
   }
 }


### PR DESCRIPTION
## Summary

Replaces 6 VM action endpoints (start, stop, forceStop, restart, pause, resume) with typed GraphQL mutations. The 3 legacy actions without GraphQL equivalents (hibernate, remove-vm, remove-vm-and-disks) remain on VMajax.php with lazily-loaded CSRF tokens.

## What changed

### New files
- **`backend/src/services/unraid-graphql.ts`** — GraphQL client using `POST /graphql` with session cookie auth. Dependency-injected cookie getter for testability.
- **`backend/__tests__/unraid-graphql.test.ts`** — 15 unit tests covering all 6 mutations (success, GraphQL errors, network errors, uninitialized client, missing cookie)

### Modified files
- **`backend/src/services/unraid.ts`** — 6 action functions now delegate to `unraid-graphql.ts` instead of posting to `VMajax.php`. CSRF token is now lazy-loaded only when calling one of the 3 legacy actions. `getCookie` exported for GraphQL client injection.

### No changes
- Frontend (zero changes — same API contract)
- Route handlers (same export names)
- HTML scraper for VM listing (unchanged)
- Auth middleware (unchanged — same `login()` flow)
- No new npm dependencies

## Migration map

| Action | Before | After |
|---|---|---|
| start | `POST VMajax.php domain-start` | `mutation { vm { start } }` |
| stop | `POST VMajax.php domain-stop` | `mutation { vm { stop } }` |
| force-stop | `POST VMajax.php domain-destroy` | `mutation { vm { forceStop } }` |
| restart | `POST VMajax.php domain-restart` | `mutation { vm { reboot } }` |
| pause | `POST VMajax.php domain-pause` | `mutation { vm { pause } }` |
| resume | `POST VMajax.php domain-resume` | `mutation { vm { resume } }` |
| hibernate | `POST VMajax.php domain-pmsuspend` | unchanged (no GraphQL equivalent) |
| remove-vm | `POST VMajax.php domain-undefine` | unchanged |
| remove-vm-and-disks | `POST VMajax.php domain-delete` | unchanged |

## Benefits
- No CSRF token needed for 6 of 9 actions (saves one HTTP round-trip per request to the legacy `/Dashboard` scrape)
- Structured error handling via GraphQL errors instead of HTML parsing
- Future-proof: GraphQL is the official Unraid API, VMajax.php is internal/undocumented
- Session cookie reused — no new auth mechanism required

## Tests
```
Tests: 18 passed (3 existing + 15 new)
Suites: 2 passed
Build: clean
```