### PR TITLE
docs: rewrite README + add usage examples and reverse proxy configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,190 @@
-# Unraid VM CP (Alpha)
-In Alpha
+# Unraid VM CP
 
-Unraid VM CP is a project that provides additional functionality for [Unraid](https://unraid.net/). The purpose of this project is to allow Unraid users to give access to manage their VMs without requiring the recipient to have their own Unraid login credentials.
+> **Alpha** — A delegated VM control panel for Unraid. Give users access to specific VMs without sharing your Unraid root credentials.
 
-## Notice
-I work on this project in my spare time, so sometimes I won't be able to update it or fix issues as quickly as I want, but I remain committed to supporting it. If this project has been helpful to you, please consider sponsoring it so that I can continue working on it.
+Unraid VM CP is a web application that sits between your Unraid server and your users. The admin (you) logs in with Unraid credentials, creates local user accounts, links specific VMs to those users, and sets granular permissions for what they can do. Local users log in with their own username/password and see only the VMs you've assigned them.
 
-## Stack
-- Overall
-  - Docker
-  - concurrently
-  - pnpm
-- Frontend
-  - Solidjs
-  - TypeScript
-- Backend
-  - Nodejs
-  - TypeScript
-  - Sequlize (sqlite)
-  - express
+---
 
 ## Features
-- Gives you the ability to grant access and permissions to specific VMs for designated users.
-- Able to control a VM without needing to login to [Unraid](https://unraid.net/).
 
-## How does Unraid VM CP work?
-The system's architecture is relatively simple, consisting of two primary components: the Frontend and the Backend. While the Frontend is straightforward, the Backend is more complex in comparison.
+- **Delegated access** — let friends, family, or colleagues control VMs without giving them your Unraid root password
+- **Granular permissions** — per-VM, per-action control: Start, Stop, Restart, Force Stop, Pause, Resume, Hibernate, Remove VM, Remove VM and Disks
+- **Multi-user** — create as many local accounts as you need, each with different VM assignments
+- **Web UI** — clean SolidJS frontend with VM status indicators, dropdown actions, and user management
+- **Reverse proxy ready** — CORS and proxy trust headers supported for nginx, Traefik, Caddy, etc.
+- **Docker-first** — single lightweight container (Bun + Alpine), pre-built images on GHCR
 
-We call the Unraid API directly, using endpoints that were found by inspecting network requests. These endpoints are not officially supported, so if the API returns unexpected results, the backend may break. To avoid issues, please use caution after Unraid updates and stay informed about this project.
+---
 
-## What happens if Unraid introduces a feature to create a managed user with VM access?
-If that feature becomes available and this project no longer addresses any other outstanding issues, then I will consider archiving it. It would be great if Unraid offers such functionality in the future.
+## Tech Stack
 
-## Docker
-Build
+| Layer | Technology |
+|-------|-----------|
+| Runtime | [Bun](https://bun.sh/) |
+| Backend | [Elysia](https://elysiajs.com/) |
+| Database | SQLite (Bun native) |
+| ORM | [Drizzle ORM](https://orm.drizzle.team/) |
+| Frontend | [SolidJS](https://www.solidjs.com/) + [Vite](https://vitejs.dev/) |
+| Auth | JWT + bcrypt |
+| Container | Docker (Alpine-based) |
+
+---
+
+## Quick Start
+
+```bash
+docker run -d \
+  --name unraid-vm-cp \
+  -p 8787:8787 \
+  -e UNRAID_IP=192.168.1.100 \
+  -e UNRAID_IS_HTTPS=false \
+  -e UNRAID_USERNAME=root \
+  -e UNRAID_PASSWORD='your-password' \
+  -e JWT_SECRET='a-random-string-at-least-16-chars' \
+  ghcr.io/npmsteven/unraid-vm-cp:latest
 ```
-docker build -t unraid-vm-cp .
+
+Then open `http://localhost:8787` and log in with your Unraid credentials.
+
+---
+
+## Installation
+
+### Docker Run
+
+```bash
+docker run -d \
+  --name unraid-vm-cp \
+  -p 8787:8787 \
+  --env-file .env \
+  -v unraid-vm-cp-data:/app/backend \
+  ghcr.io/npmsteven/unraid-vm-cp:latest
 ```
-Run
+
+The volume `-v unraid-vm-cp-data:/app/backend` persists the SQLite database so you retain users and VM links across container updates.
+
+### Docker Compose
+
+See [`examples/docker-compose.yml`](examples/docker-compose.yml) for a production-ready compose file with healthchecks, persistent storage, and environment configuration.
+
+### Unraid Docker Template
+
+Place [`unraid-vm-cp.xml`](unraid-vm-cp.xml) in your Unraid flash drive's `/boot/config/plugins/dockerMan/templates-user/` directory, then install it from the Unraid Docker UI. The template prompts for all required environment variables.
+
+---
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `UNRAID_IP` | Yes | — | IP address of your Unraid server |
+| `UNRAID_IS_HTTPS` | Yes | — | `true` if Unraid uses HTTPS, `false` otherwise |
+| `UNRAID_USERNAME` | Yes | — | Unraid root username |
+| `UNRAID_PASSWORD` | Yes | — | Unraid root password (stored in plaintext — keep your flash drive secure) |
+| `JWT_SECRET` | Yes | — | Random string (min 16 characters) for signing tokens |
+| `UNRAID_PORT` | No | — | Custom port if Unraid runs on a non-standard port (e.g. `443`, `8443`) |
+| `SERVER_PORT` | No | `8787` | Port the backend listens on |
+| `SERVE_FRONTEND` | No | `true` | Set to `false` to serve frontend separately (legacy dual-port mode) |
+| `FRONTEND_DIST_PATH` | No | `../frontend/dist` | Path to the frontend build output |
+| `CORS_ORIGIN` | No | `*` | CORS allowed origin. Set to your domain behind a reverse proxy |
+| `TRUST_PROXY` | No | — | Proxy trust setting: `true`, number of hops, or CIDR string |
+
+---
+
+## Usage
+
+### Admin Workflow
+
+1. **Log in** with your Unraid username and password
+2. Go to **Users** → **Create User** to add a local account
+3. Click the user's dropdown → **VMs** to see their linked VMs
+4. Click **Link a VM** to select an Unraid VM and assign default permissions (Start, Stop, Restart)
+5. On the VM card dropdown, click **Permissions** to customize the 9 granular actions
+6. The local user can now log in with their own credentials and only see/control their assigned VMs
+
+### Local User Workflow
+
+1. **Log in** with the username/password the admin gave you
+2. Your **VMs** page shows only the VMs assigned to you, with status indicators
+3. Use the **dropdown** on each VM card to start, stop, restart, etc. (only actions the admin permitted)
+
+---
+
+## Examples
+
+Common setup patterns and usage scenarios. All files in [`examples/`](examples/).
+
+### Deployment
+
+| File | Description |
+|------|-------------|
+| [`docker-compose.yml`](examples/docker-compose.yml) | Production compose with volumes, healthcheck, env_file |
+
+### Reverse Proxy
+
+| File | Description |
+|------|-------------|
+| [`nginx-reverse-proxy.conf`](examples/nginx-reverse-proxy.conf) | Nginx config with SSL termination, WebSocket support |
+| [`traefik-reverse-proxy.yml`](examples/traefik-reverse-proxy.yml) | Traefik labels for docker-compose |
+| [`Caddyfile`](examples/Caddyfile) | Caddy reverse proxy (one-liner) |
+
+### Usage Scenarios
+
+| File | Description |
+|------|-------------|
+| [`scenario-readonly-access.md`](examples/scenario-readonly-access.md) | Let a friend view VM status but not change anything |
+| [`scenario-power-user.md`](examples/scenario-power-user.md) | Give a trusted user full control over specific VMs |
+| [`scenario-multi-user-family.md`](examples/scenario-multi-user-family.md) | Family server — different VMs for different household members |
+
+---
+
+## Development
+
+```bash
+# Install dependencies
+pnpm install
+cd backend && bun install
+cd ../frontend && bun install
+
+# Run in development (backend on 8787, frontend dev server on 3000 with API proxy)
+pnpm run start:all
+
+# Run tests
+cd backend && bun test
+cd frontend && bun run test
 ```
-docker run -p 8787:8787 -p 8786:8786 --env-file ./.env -t unraid-vm-cp
-```
 
-## Built With
+### Commands
 
-- [Node.js](https://nodejs.org/en/) - The JavaScript runtime used to run the server-side code.
-- [Express](https://expressjs.com/) - The web framework used to build the REST API.
+| Command | Description |
+|---------|-------------|
+| `pnpm run dev:backend` | Backend with hot reload (`bun --watch`) |
+| `pnpm run dev:frontend` | Vite dev server with API proxy |
+| `pnpm run start:all` | Both concurrently (dev mode) |
+| `pnpm run build:frontend` | Production frontend build |
+| `pnpm run start:prod` | Production backend (serves frontend statically) |
 
-## Authors
+---
 
-- **Steven Rafferty** - [npmSteven](https://github.com/npmSteven)
+## Caveats & Limitations
+
+- **Undocumented APIs** — This project uses Unraid's internal, undocumented HTML pages and GraphQL/AJAX endpoints. These may break after Unraid updates. Exercise caution after upgrading Unraid.
+- **Plaintext password** — Your Unraid root password is stored as an environment variable in plaintext. Ensure your Docker environment and Unraid flash drive are secure.
+- **Alpha software** — This project is in active development. Expect changes, and please report issues.
+- **Single Unraid target** — The backend connects to one Unraid server at a time. Multi-server setups would require multiple container instances.
+- **Unraid 7.2+ hint** — Unraid OS 7.2 introduced an official GraphQL API. Once stable, this project may transition to using it instead of scraping HTML.
+
+---
 
 ## License
 
-This project is licensed under the AGPL 3.0 - see the [LICENSE](LICENSE) file for details.
+GNU AGPL 3.0 — see [LICENSE](LICENSE).
 
-## Acknowledgments
+## Author
 
-- [Unraid](https://unraid.net/) for providing the foundation for this project.
+**Steven Rafferty** — [@npmSteven](https://github.com/npmSteven)
+
+---
+
+*If this project has been helpful, consider [sponsoring](https://www.buymeacoffee.com/npmSteven) so I can keep working on it.*

--- a/examples/Caddyfile
+++ b/examples/Caddyfile
@@ -1,0 +1,9 @@
+# Caddy reverse proxy for Unraid VM CP
+# Place in /etc/caddy/Caddyfile or your Caddy config location
+#
+# Caddy handles SSL automatically via Let's Encrypt.
+# No separate cert management needed.
+
+vm-control.example.com {
+    reverse_proxy 127.0.0.1:8787
+}

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3.8"
+
+services:
+  unraid-vm-cp:
+    image: ghcr.io/npmsteven/unraid-vm-cp:latest
+    container_name: unraid-vm-cp
+    restart: unless-stopped
+    ports:
+      - "8787:8787"
+    environment:
+      - UNRAID_IP=${UNRAID_IP}
+      - UNRAID_PORT=${UNRAID_PORT:-}
+      - UNRAID_IS_HTTPS=${UNRAID_IS_HTTPS}
+      - UNRAID_USERNAME=${UNRAID_USERNAME}
+      - UNRAID_PASSWORD=${UNRAID_PASSWORD}
+      - JWT_SECRET=${JWT_SECRET}
+      # Optional — uncomment and set if needed:
+      # - SERVER_PORT=8787
+      # - SERVE_FRONTEND=true
+      # - CORS_ORIGIN=https://your-domain.com
+      # - TRUST_PROXY=true
+    env_file:
+      - .env
+    volumes:
+      - data:/app/backend
+    healthcheck:
+      test: ["CMD", "bun", "-e", "fetch('http://localhost:8787/health').then(r => process.exit(r.status === 200 ? 0 : 1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  data:

--- a/examples/nginx-reverse-proxy.conf
+++ b/examples/nginx-reverse-proxy.conf
@@ -1,0 +1,49 @@
+# Nginx reverse proxy for Unraid VM CP
+# Place in /etc/nginx/sites-available/ and symlink to sites-enabled/
+#
+# Assumptions:
+#   - Unraid VM CP is running on localhost:8787
+#   - SSL certificates managed by certbot or placed manually
+#   - Domain: vm-control.example.com (replace with yours)
+
+server {
+    listen 80;
+    server_name vm-control.example.com;
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name vm-control.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/vm-control.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/vm-control.example.com/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+    # Increase body size if users upload large payloads
+    client_max_body_size 10M;
+
+    location / {
+        proxy_pass http://127.0.0.1:8787;
+
+        proxy_http_version 1.1;
+
+        # WebSocket support (for future real-time status)
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        # Standard proxy headers
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+
+        # Timeouts
+        proxy_connect_timeout 60s;
+        proxy_send_timeout    60s;
+        proxy_read_timeout    60s;
+    }
+}

--- a/examples/scenario-multi-user-family.md
+++ b/examples/scenario-multi-user-family.md
@@ -1,0 +1,45 @@
+# Scenario: Multi-User Family Server
+
+**Use case:** A home server running multiple VMs for different family members — a gaming VM for one person, a development environment for another, a media server that everyone uses but only one person manages.
+
+## Setup
+
+### Step 1: Create users for each family member
+
+| User | Purpose |
+|------|---------|
+| `alice` | Owns the gaming VM, full control |
+| `bob` | Owns the dev VM, full control |
+| `charlie` | View-only access to the media server to check status |
+
+### Step 2: Link VMs and set permissions
+
+| User | VM | Permissions |
+|------|----|-------------|
+| `alice` | `Gaming PC (Windows)` | Start, Stop, Restart, Pause, Resume |
+| `alice` | `Media Server (Plex)` | View only (all unchecked) |
+| `bob` | `Dev Environment (Ubuntu)` | All except Remove VM and Disks |
+| `bob` | `Media Server (Plex)` | View only (all unchecked) |
+| `charlie` | `Media Server (Plex)` | View only (all unchecked) |
+
+### Step 3: Each person logs in with their own credentials
+
+- **Alice** sees two VM cards: `Gaming PC` (full control) and `Media Server` (status only). She can start her gaming VM after a server reboot without bothering anyone.
+- **Bob** sees two VM cards: `Dev Environment` (full control, no destructive remove) and `Media Server` (status only).
+- **Charlie** sees one VM card: `Media Server` (status only). He can check if Plex is running but can't touch anything.
+
+## Benefits
+
+| Benefit | How |
+|---------|-----|
+| **No shared credentials** | Each person has their own login, no Unraid root password shared |
+| **No accidental interference** | Alice can't stop Bob's dev VM, Bob can't reboot Alice's gaming VM |
+| **Self-service** | Family members can start/stop their own VMs without asking you |
+| **Audit trail** | You know who started or stopped a VM based on the user account |
+| **Easy cleanup** | If someone no longer needs access, delete their user account — all VM links and permissions are removed automatically |
+
+## Extending
+
+- **Kids who play games**: Give Start/Stop/Restart only — no remove or hibernate.
+- **Guest access**: Create a `guest` user linked to a guest VM only (if you run one).
+- **Maintenance mode**: Temporarily disable all actions for a user while you perform server maintenance.

--- a/examples/scenario-power-user.md
+++ b/examples/scenario-power-user.md
@@ -1,0 +1,53 @@
+# Scenario: Power User with Full Control
+
+**Use case:** A trusted colleague or team member needs full control over specific VMs — start, stop, restart, force stop, hibernate, and remove — but only on VMs you designate.
+
+## Setup
+
+1. **Create the user:**
+   - **Users → Create User**
+   - Username: `devops`
+   - Password: `strong-unique-password`
+
+2. **Link each VM and set full permissions:**
+   - **Users → devops → VMs → Link a VM**
+   - Select each VM they should manage
+   - For each linked VM, open the dropdown → **Permissions**
+   - Enable all actions:
+     - Start ✓
+     - Stop ✓
+     - Restart ✓
+     - Force Stop ✓
+     - Pause ✓
+     - Resume ✓
+     - Hibernate ✓
+     - Remove VM ✓
+     - Remove VM and Disks ✓ *(use with caution)*
+   - Click **Update**
+
+3. **Repeat** for each VM they should manage.
+
+## Result
+
+`devops` can fully manage the assigned VMs: power-cycle test environments, hibernate idle dev VMs, pause long-running builds. They cannot see or touch any VMs you haven't explicitly linked.
+
+## Security Considerations
+
+| Risk | Mitigation |
+|------|------------|
+| User can delete a VM and its disks | Disable `canRemoveVMAndDisks` if you want them to only stop/start |
+| Password shared or leaked | Change the password from **Users → edit** |
+| User should not access production VMs | Simply don't link production VMs to this user |
+
+## Alternative: Per-VM Permission Profiles
+
+You can mix power-user access on some VMs with read-only on others:
+
+| VM | Permissions |
+|----|------------|
+| `Dev Server` | All enabled (full control) |
+| `CI Runner` | Start, Stop, Restart only (no remove) |
+| `Staging DB` | Start, Stop, Pause, Resume (no force stop, no remove) |
+| `Monitoring` | All disabled (read-only) |
+
+Each VM's permissions are set independently — the same user can have different access levels across VMs.

--- a/examples/scenario-readonly-access.md
+++ b/examples/scenario-readonly-access.md
@@ -1,0 +1,33 @@
+# Scenario: Read-Only VM Access
+
+**Use case:** A friend or colleague needs to check if a VM is running, but should not be able to start, stop, or modify it.
+
+## Setup
+
+1. **Create a user** in the Unraid VM CP admin panel:
+   - Go to **Users → Create User**
+   - Username: `friend`
+   - Password: `something-secure`
+
+2. **Link the VM** to the user:
+   - Go to **Users → friend → VMs**
+   - Click **Link a VM**
+   - Select the VM (e.g., `Web Server`)
+   - A link is created with default permissions (Start, Stop, Restart enabled)
+
+3. **Restrict to read-only**:
+   - On the linked VM card, open the dropdown → **Permissions**
+   - Uncheck **every action** (Start, Stop, Restart, Force Stop, Pause, Resume, Hibernate, Remove VM, Remove VM and Disks)
+   - Click **Update**
+
+## Result
+
+When `friend` logs in, they will see the VM card with its status (running/stopped/paused), OS, RAM, storage, and IP address — but every dropdown action will be disabled. The user can **view** but cannot **change** anything.
+
+## Why This Is Useful
+
+| Situation | Benefit |
+|-----------|---------|
+| Developer checking if a staging server is up | See status without accidentally shutting it down |
+| Non-technical stakeholder monitoring a service | Minimal training needed — just look at the color |
+| Temporary access for an audit | Grant view-only and revoke later without risk |

--- a/examples/traefik-reverse-proxy.yml
+++ b/examples/traefik-reverse-proxy.yml
@@ -1,0 +1,31 @@
+# Add these labels to your Unraid VM CP service in docker-compose.yml
+# when running behind Traefik.
+#
+# Assumes Traefik is already running with the 'web' and 'websecure'
+# entrypoints configured, and a certificate resolver named 'letsencrypt'.
+
+services:
+  unraid-vm-cp:
+    # ... your existing config ...
+    labels:
+      - "traefik.enable=true"
+
+      # HTTP → HTTPS redirect
+      - "traefik.http.routers.unraid-vm-cp.rule=Host(`vm-control.example.com`)"
+      - "traefik.http.routers.unraid-vm-cp.entrypoints=web"
+      - "traefik.http.routers.unraid-vm-cp.middlewares=redirect-to-https"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+
+      # HTTPS router
+      - "traefik.http.routers.unraid-vm-cp-secure.rule=Host(`vm-control.example.com`)"
+      - "traefik.http.routers.unraid-vm-cp-secure.entrypoints=websecure"
+      - "traefik.http.routers.unraid-vm-cp-secure.tls=true"
+      - "traefik.http.routers.unraid-vm-cp-secure.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.unraid-vm-cp-secure.service=unraid-vm-cp"
+
+      # Backend service
+      - "traefik.http.services.unraid-vm-cp.loadbalancer.server.port=8787"
+
+    # Remove the ports section if Traefik handles all ingress
+    # ports:
+    #   - "8787:8787"


### PR DESCRIPTION
## What

Complete rewrite of the README to reflect the actual tech stack and provide clear setup/usage instructions. Plus new examples for common deployment patterns and real-world usage scenarios.

### README Changes
- Corrected tech stack (Bun, Elysia, Drizzle, SolidJS — was Express, Sequelize, Node.js)
- Added quick start one-liner
- Full environment variable reference table
- Step-by-step admin and local user workflows
- Development setup and commands
- Caveats and limitations section

### New  directory

**Deployment:**
- `docker-compose.yml` — production compose with persistent volume, healthcheck

**Reverse Proxy:**
- `nginx-reverse-proxy.conf` — Nginx with SSL, WebSocket headers
- `traefik-reverse-proxy.yml` — Traefik labels for HTTP→HTTPS, Let's Encrypt
- `Caddyfile` — Caddy one-liner (auto-SSL)

**Usage Scenarios:**
- `scenario-readonly-access.md` — VM viewer with all permissions off
- `scenario-power-user.md` — Full control per VM with mixed-permission profiles
- `scenario-multi-user-family.md` — Family server with different VMs per person

### Validation
All tech stack claims verified against actual package.json files, Dockerfile, and source code. Environment variables cross-referenced with backend/config.ts.